### PR TITLE
Ibexa scheduled visibility fixes

### DIFF
--- a/.php-cs-fixer.php
+++ b/.php-cs-fixer.php
@@ -8,33 +8,34 @@ $finder = PhpCsFixer\Finder::create()
 
 $config = new PhpCsFixer\Config();
 return $config
+    ->setRiskyAllowed(true)
     ->setRules([
-        '@PSR12' => true,
-        '@PSR12:risky' => true,
+        '@PER' => true,
+        '@PER:risky' => true,
         '@PhpCsFixer' => true,
         '@PhpCsFixer:risky' => true,
 
         // Overrides for rules included in PhpCsFixer rule sets
         'concat_space' => ['spacing' => 'one'],
+        'fully_qualified_strict_types' => ['phpdoc_tags' => []],
         'method_chaining_indentation' => false,
         'multiline_whitespace_before_semicolons' => false,
         'native_function_invocation' => ['include' => ['@all']],
         'no_superfluous_phpdoc_tags' => false,
         'no_unset_on_property' => false,
         'ordered_imports' => ['imports_order' => ['class', 'function', 'const'], 'sort_algorithm' => 'alpha'],
+        'ordered_types' => ['null_adjustment' => 'always_last', 'sort_algorithm' => 'alpha'],
         'php_unit_internal_class' => false,
         'php_unit_test_case_static_method_calls' => ['call_type' => 'self'],
         'php_unit_test_class_requires_covers' => false,
         'phpdoc_align' => false,
+        'phpdoc_order' => ['order' => ['param', 'throws', 'return']],
         'phpdoc_types_order' => ['null_adjustment' => 'always_last', 'sort_algorithm' => 'none'],
         'single_line_comment_style' => false,
-        'trailing_comma_in_multiline' => ['elements' => ['arrays', 'arguments']],
+        'trailing_comma_in_multiline' => ['elements' => ['arrays', 'arguments', 'match', 'parameters']],
         'yoda_style' => false,
-        'php_unit_strict' => false,
-        'php_unit_test_annotation' => false,
 
         // Additional rules
-        'return_assignment' => false,
         'date_time_immutable' => true,
         'declare_strict_types' => true,
         'global_namespace_import' => [
@@ -42,7 +43,6 @@ return $config
             'import_constants' => true,
             'import_functions' => true,
         ],
-        'list_syntax' => ['syntax' => 'short'],
         'heredoc_indentation' => ['indentation' => 'same_as_start'],
         'mb_str_functions' => true,
         'native_constant_invocation' => true,
@@ -50,7 +50,7 @@ return $config
         'static_lambda' => true,
         'ternary_to_null_coalescing' => true,
         'use_arrow_functions' => true,
-   ])
+    ])
     ->setRiskyAllowed(true)
     ->setFinder($finder)
 ;

--- a/bundle/Command/ScheduledVisibilityUpdateCommand.php
+++ b/bundle/Command/ScheduledVisibilityUpdateCommand.php
@@ -11,6 +11,7 @@ use Ibexa\Contracts\Core\Repository\ContentTypeService;
 use Ibexa\Contracts\Core\Repository\Exceptions\NotFoundException;
 use Ibexa\Contracts\Core\Repository\LanguageService;
 use Ibexa\Contracts\Core\Repository\Repository;
+use Ibexa\Contracts\Core\Repository\Values\Content\ContentInfo;
 use Ibexa\Contracts\Core\Repository\Values\Content\Language;
 use Netgen\Bundle\IbexaScheduledVisibilityBundle\Core\Configuration;
 use Netgen\Bundle\IbexaScheduledVisibilityBundle\Core\Exception\InvalidStateException;
@@ -30,6 +31,7 @@ use Throwable;
 
 use function count;
 use function sprintf;
+use function time;
 
 final class ScheduledVisibilityUpdateCommand extends Command
 {
@@ -205,8 +207,10 @@ final class ScheduledVisibilityUpdateCommand extends Command
             ->select('id', 'initial_language_id')
             ->from('ezcontentobject')
             ->where('published != :unpublished')
+            ->andWhere('status != :trashed')
             ->orderBy('id', 'ASC')
-            ->setParameter('unpublished', 0);
+            ->setParameter('unpublished', 0)
+            ->setParameter('trashed', ContentInfo::STATUS_TRASHED);
 
         $this->applySince($queryBuilder, $since);
         $this->applyContentTypes($queryBuilder, $contentTypeIds);
@@ -254,6 +258,7 @@ final class ScheduledVisibilityUpdateCommand extends Command
                 ->from('ezcontentobject')
                 ->where('published != :unpublished')
                 ->setParameter('unpublished', 0)
+                ->setParameter('trashed', ContentInfo::STATUS_TRASHED)
                 ->setMaxResults(1);
 
             $this->applySince($queryBuilder, $since);

--- a/docs/reference/usage.rst
+++ b/docs/reference/usage.rst
@@ -39,4 +39,4 @@ By default it is set to 1024.
 The command also has a ``since`` option that limits processing to content items modified since the given number of days.
 By default it is not set, which means all items will be processed.
 Command can be executed with: ``bin/console ngscheduledvisibility:update``.
-For this mechanism to work how it was intended, this command should be set as cron job.
+For this mechanism to work how it was intended, this command should be set as cron job with ``--no-interaction`` option.


### PR DESCRIPTION
I updated docs regarding --no-interaction option for cron job command. https://netgen.atlassian.net/browse/NGSTACK-914. 
Trashed content will not end up in search results anymore. https://netgen.atlassian.net/browse/NGSTACK-913
I also updated php-cs-fixer rules.