### PR TITLE
NGSTACK-1002 upgrade bundle to ibexa 5

### DIFF
--- a/.github/workflows/tests.yaml
+++ b/.github/workflows/tests.yaml
@@ -15,7 +15,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        php: ['8.1']
+        php: ['8.3']
         phpunit: ['phpunit.xml', 'phpunit-integration-legacy.xml']
 
     steps:

--- a/.gitignore
+++ b/.gitignore
@@ -3,3 +3,4 @@ composer.lock
 .phpunit.result.cache
 .php-cs-fixer.cache
 var
+.phpunit.cache

--- a/bundle/Core/ScheduledVisibilityService.php
+++ b/bundle/Core/ScheduledVisibilityService.php
@@ -132,8 +132,8 @@ final class ScheduledVisibilityService
         }
 
         if (
-            ($publishFromField->fieldTypeIdentifier !== 'ezdatetime' && $publishFromField->fieldTypeIdentifier !== 'ezdate')
-            || ($publishToField->fieldTypeIdentifier !== 'ezdatetime' && $publishToField->fieldTypeIdentifier !== 'ezdate')
+            ($publishFromField->fieldTypeIdentifier !== 'ibexa_datetime' && $publishFromField->fieldTypeIdentifier !== 'ibexa_date')
+            || ($publishToField->fieldTypeIdentifier !== 'ibexa_datetime' && $publishToField->fieldTypeIdentifier !== 'ibexa_date')
         ) {
             return false;
         }

--- a/composer.json
+++ b/composer.json
@@ -10,12 +10,12 @@
         }
     ],
     "require": {
-        "php": ">=8.1",
-        "ibexa/core": "^4.5"
+        "php": ">=8.3",
+        "ibexa/core": "^5.0"
     },
     "require-dev": {
-        "phpunit/phpunit": "^10",
-        "matthiasnoback/symfony-dependency-injection-test": "^4.1"
+        "phpunit/phpunit": "^12",
+        "matthiasnoback/symfony-dependency-injection-test": "^6.0"
     },
     "minimum-stability": "dev",
     "prefer-stable": true,

--- a/tests/bundle/DependencyInjection/NetgenIbexaScheduledVisibilityTest.php
+++ b/tests/bundle/DependencyInjection/NetgenIbexaScheduledVisibilityTest.php
@@ -6,6 +6,7 @@ namespace Netgen\IbexaScheduledVisibility\Tests\DependencyInjection;
 
 use Matthias\SymfonyDependencyInjectionTest\PhpUnit\AbstractExtensionTestCase;
 use Netgen\Bundle\IbexaScheduledVisibilityBundle\DependencyInjection\NetgenIbexaScheduledVisibilityExtension;
+use PHPUnit\Framework\Attributes\DataProvider;
 
 final class NetgenIbexaScheduledVisibilityTest extends AbstractExtensionTestCase
 {
@@ -277,9 +278,7 @@ final class NetgenIbexaScheduledVisibilityTest extends AbstractExtensionTestCase
         ];
     }
 
-    /**
-     * @dataProvider provideDefaultConfigurationCases
-     */
+    #[DataProvider('provideDefaultConfigurationCases')]
     public function testDefaultConfiguration(array $configuration): void
     {
         $this->load($configuration);
@@ -322,9 +321,7 @@ final class NetgenIbexaScheduledVisibilityTest extends AbstractExtensionTestCase
         );
     }
 
-    /**
-     * @dataProvider provideEnabledConfigurationCases
-     */
+    #[DataProvider('provideEnabledConfigurationCases')]
     public function testEnabledConfiguration(array $configuration, bool $expectedParameterValue): void
     {
         $this->load($configuration);
@@ -335,9 +332,7 @@ final class NetgenIbexaScheduledVisibilityTest extends AbstractExtensionTestCase
         );
     }
 
-    /**
-     * @dataProvider provideHandlerConfigurationCases
-     */
+    #[DataProvider('provideHandlerConfigurationCases')]
     public function testHandlerConfiguration(array $configuration, string $expectedParameterValue): void
     {
         $this->load($configuration);
@@ -348,9 +343,7 @@ final class NetgenIbexaScheduledVisibilityTest extends AbstractExtensionTestCase
         );
     }
 
-    /**
-     * @dataProvider provideSectionConfigurationCases
-     */
+    #[DataProvider('provideSectionConfigurationCases')]
     public function testSectionConfiguration(array $configuration, array $expectedParameterValues): void
     {
         $this->load($configuration);
@@ -365,9 +358,7 @@ final class NetgenIbexaScheduledVisibilityTest extends AbstractExtensionTestCase
         );
     }
 
-    /**
-     * @dataProvider provideObjectStateConfigurationCases
-     */
+    #[DataProvider('provideObjectStateConfigurationCases')]
     public function testObjectStateConfiguration(array $configuration, array $expectedParameterValues): void
     {
         $this->load($configuration);
@@ -386,9 +377,7 @@ final class NetgenIbexaScheduledVisibilityTest extends AbstractExtensionTestCase
         );
     }
 
-    /**
-     * @dataProvider provideContentTypesConfigurationCases
-     */
+    #[DataProvider('provideContentTypesConfigurationCases')]
     public function testContentTypesConfiguration(array $configuration, array $expectedParameterValues): void
     {
         $this->load($configuration);

--- a/tests/bundle/Integration/BaseTest.php
+++ b/tests/bundle/Integration/BaseTest.php
@@ -25,42 +25,42 @@ abstract class BaseTest extends APIBaseTest
             [
                 [
                     'publish_from' => null,
-                    'publish_to' => new DateTime('tomorrow'),
+                    'publish_to' => new DateTime('tomorrow', new \DateTimeZone('UTC')),
                 ],
                 false,
             ],
             [
                 [
                     'publish_from' => null,
-                    'publish_to' => new DateTime('yesterday'),
+                    'publish_to' => new DateTime('yesterday', new \DateTimeZone('UTC')),
                 ],
                 true,
             ],
             [
                 [
-                    'publish_from' => new DateTime('2 days ago'),
-                    'publish_to' => new DateTime('yesterday'),
+                    'publish_from' => new DateTime('2 days ago', new \DateTimeZone('UTC')),
+                    'publish_to' => new DateTime('yesterday', new \DateTimeZone('UTC')),
                 ],
                 true,
             ],
             [
                 [
-                    'publish_from' => new DateTime('yesterday'),
-                    'publish_to' => new DateTime('tomorrow'),
+                    'publish_from' => new DateTime('yesterday', new \DateTimeZone('UTC')),
+                    'publish_to' => new DateTime('tomorrow', new \DateTimeZone('UTC')),
                 ],
                 false,
             ],
             [
                 [
-                    'publish_from' => new DateTime('tomorrow'),
+                    'publish_from' => new DateTime('tomorrow', new \DateTimeZone('UTC')),
                     'publish_to' => null,
                 ],
                 true,
             ],
             [
                 [
-                    'publish_from' => new DateTime('tomorrow'),
-                    'publish_to' => new DateTime('2 day'),
+                    'publish_from' => new DateTime('tomorrow', new \DateTimeZone('UTC')),
+                    'publish_to' => new DateTime('2 day', new \DateTimeZone('UTC')),
                 ],
                 true,
             ],

--- a/tests/bundle/Integration/BaseTest.php
+++ b/tests/bundle/Integration/BaseTest.php
@@ -7,7 +7,7 @@ namespace Netgen\IbexaScheduledVisibility\Tests\Integration;
 use DateTime;
 use Ibexa\Contracts\Core\Repository\Values\Content\Content;
 use Ibexa\Contracts\Core\Repository\Values\ContentType\ContentType;
-use Ibexa\Tests\Integration\Core\Repository\BaseTest as APIBaseTest;
+use Ibexa\Tests\Integration\Core\Repository\BaseTestCase as APIBaseTest;
 use Netgen\Bundle\IbexaScheduledVisibilityBundle\Core\ScheduledVisibilityService;
 
 abstract class BaseTest extends APIBaseTest

--- a/tests/bundle/Integration/BaseTest.php
+++ b/tests/bundle/Integration/BaseTest.php
@@ -93,14 +93,14 @@ abstract class BaseTest extends APIBaseTest
         $typeCreate->creatorId = $this->generateId('user', $permissionResolver->getCurrentUserReference()->getUserId());
         $typeCreate->creationDate = $this->createDateTime();
 
-        $publishFromFieldCreate = $contentTypeService->newFieldDefinitionCreateStruct('publish_from', 'ezdate');
+        $publishFromFieldCreate = $contentTypeService->newFieldDefinitionCreateStruct('publish_from', 'ibexa_date');
         $publishFromFieldCreate->names = [
             'eng-GB' => 'Publish from',
         ];
         $publishFromFieldCreate->position = 1;
         $typeCreate->addFieldDefinition($publishFromFieldCreate);
 
-        $publishToFieldCreate = $contentTypeService->newFieldDefinitionCreateStruct('publish_to', 'ezdatetime');
+        $publishToFieldCreate = $contentTypeService->newFieldDefinitionCreateStruct('publish_to', 'ibexa_datetime');
         $publishToFieldCreate->names = [
             'eng-GB' => 'Publish to',
         ];

--- a/tests/bundle/Integration/ContentAndLocationTest.php
+++ b/tests/bundle/Integration/ContentAndLocationTest.php
@@ -7,12 +7,11 @@ namespace Netgen\IbexaScheduledVisibility\Tests\Integration;
 use Netgen\Bundle\IbexaScheduledVisibilityBundle\Core\VisibilityHandler\Content;
 use Netgen\Bundle\IbexaScheduledVisibilityBundle\Core\VisibilityHandler\ContentAndLocation;
 use Netgen\Bundle\IbexaScheduledVisibilityBundle\Core\VisibilityHandler\Location;
+use PHPUnit\Framework\Attributes\DataProvider;
 
 final class ContentAndLocationTest extends BaseTest
 {
-    /**
-     * @dataProvider provideCases
-     */
+    #[DataProvider('provideCases')]
     public function testUpdateVisibility(array $configuration, bool $expectedHidden)
     {
         $scheduledVisibilityService = $this->getScheduledVisibilityService();

--- a/tests/bundle/Integration/ContentTest.php
+++ b/tests/bundle/Integration/ContentTest.php
@@ -5,12 +5,11 @@ declare(strict_types=1);
 namespace Netgen\IbexaScheduledVisibility\Tests\Integration;
 
 use Netgen\Bundle\IbexaScheduledVisibilityBundle\Core\VisibilityHandler\Content;
+use PHPUnit\Framework\Attributes\DataProvider;
 
 final class ContentTest extends BaseTest
 {
-    /**
-     * @dataProvider provideCases
-     */
+    #[DataProvider('provideCases')]
     public function testUpdateVisibility(array $configuration, bool $expectedHidden)
     {
         $scheduledVisibilityService = $this->getScheduledVisibilityService();

--- a/tests/bundle/Integration/LocationTest.php
+++ b/tests/bundle/Integration/LocationTest.php
@@ -5,12 +5,11 @@ declare(strict_types=1);
 namespace Netgen\IbexaScheduledVisibility\Tests\Integration;
 
 use Netgen\Bundle\IbexaScheduledVisibilityBundle\Core\VisibilityHandler\Location;
+use PHPUnit\Framework\Attributes\DataProvider;
 
 final class LocationTest extends BaseTest
 {
-    /**
-     * @dataProvider provideCases
-     */
+    #[DataProvider('provideCases')]
     public function testUpdateVisibility(array $configuration, bool $expectedHidden)
     {
         $scheduledVisibilityService = $this->getScheduledVisibilityService();

--- a/tests/bundle/Integration/ObjectStateTest.php
+++ b/tests/bundle/Integration/ObjectStateTest.php
@@ -6,12 +6,11 @@ namespace Netgen\IbexaScheduledVisibility\Tests\Integration;
 
 use Ibexa\Contracts\Core\Repository\Values\ObjectState\ObjectState as ObjectStateValue;
 use Netgen\Bundle\IbexaScheduledVisibilityBundle\Core\VisibilityHandler\ObjectState;
+use PHPUnit\Framework\Attributes\DataProvider;
 
 final class ObjectStateTest extends BaseTest
 {
-    /**
-     * @dataProvider provideCases
-     */
+    #[DataProvider('provideCases')]
     public function testUpdateVisibility(array $configuration, bool $expectedHidden)
     {
         $scheduledVisibilityService = $this->getScheduledVisibilityService();

--- a/tests/bundle/Integration/SectionTest.php
+++ b/tests/bundle/Integration/SectionTest.php
@@ -6,12 +6,11 @@ namespace Netgen\IbexaScheduledVisibility\Tests\Integration;
 
 use Ibexa\Contracts\Core\Repository\Values\Content\Section as SectionValue;
 use Netgen\Bundle\IbexaScheduledVisibilityBundle\Core\VisibilityHandler\Section;
+use PHPUnit\Framework\Attributes\DataProvider;
 
 final class SectionTest extends BaseTest
 {
-    /**
-     * @dataProvider provideCases
-     */
+    #[DataProvider('provideCases')]
     public function testUpdateVisibility(array $configuration, bool $expectedHidden)
     {
         $scheduledVisibilityService = $this->getScheduledVisibilityService();


### PR DESCRIPTION
Upgrade bundle to Ibexa 5. Also upgraded PHP version to be at least 8.3. 

Renamed the `ezdate` and `ezdatetime` field type identifiers to `ibexa_date` and `ibexa_datetime`. 
The `ezdate` and `ezdatetime` are renamed in Ibexa 5: https://doc.ibexa.co/en/latest/release_notes/ibexa_dxp_v5.0_deprecations/#database-table-and-column-names

In `BaseTest.php` file, I added the `DateTimeZone` when creating a new `DateTime`. I had issues (locally) with this because the line `new DateTime('tomorrow')` would return today's date at midnight. 
Now, with timezone specified, the `new DateTime('tomorrow')` returns the expected result.